### PR TITLE
Fix links to new repo location and pybind spelling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
             if [[ $CIRCLE_BRANCH == "master" ]]; then
                 ./.circleci/deploy-docs.sh
                 cd gh-pages
-                git push -q https://${GH_TOKEN}@github.com/cosmo-epfl/librascal.git gh-pages
+                git push -q https://${GH_TOKEN}@github.com/lab-cosmo/librascal.git gh-pages
             fi
 
   # Special job only linting the code

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,9 +14,9 @@ linter fails on your code, the pull request will be sent back for revision
 without any further comments.
 
 It is also a good idea to browse the
-`developer's guide <https://cosmo-epfl.github.io/librascal/dev_guide/developer.html>`_,
+`developer's guide <https://lab-cosmo.github.io/librascal/dev_guide/developer.html>`_,
 especially the
-`coding conventions <https://cosmo-epfl.github.io/librascal/dev_guide/coding-convention.html>`_
+`coding conventions <https://lab-cosmo.github.io/librascal/dev_guide/coding-convention.html>`_
 for C++ code (Python code generally follows PEP 8).
 
 We now have a pull request template; please use it (especially for new
@@ -32,7 +32,7 @@ Summary of the review process
 ===============================
 
 A detailed description can be found in a separate document about the `review
-process <https://cosmo-epfl.github.io/librascal/dev_guide/review_process.html>`_
+process <https://lab-cosmo.github.io/librascal/dev_guide/review_process.html>`_
 
 For developers
  * We want a clean and tested master branch, which is why we review code and use
@@ -69,7 +69,7 @@ sent back without further comments.  The two exceptions to this rule are:
    those outputs from making it into the history in the first place)
 
 2. Stable outputs for example notebooks meant to be processed to HTML for the
-   `tutorials page <https://cosmo-epfl.github.io/librascal/tutorials/tutorials.html>`_.
+   `tutorials page <https://lab-cosmo.github.io/librascal/tutorials/tutorials.html>`_.
    "Stable" here means these are the final outputs meant to be shown to the
    public and won't be changed unless errors or omissions are discovered, or the
    tutorial is later updated or expanded.  Note that tutorials that rely on

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ librascal is currently considered a standalone code. However, we aim to
 provide enough flexibility to interface it with other codes such as
 LAMMPS and PLUMED-2.0. It can be used as a C++ library as well as a
 python module. To be able to call it from python, we have used the
-pybind11 library.
+pybind11_ library.
 
 Although at the moment is a serial-only code, we aim to write it in MPI
 so that it will be possible to take advantage of parallelization to
@@ -30,7 +30,8 @@ distributed, although we take no responsibility for its misuse.
 
 For more information, have a look at the documentation_!
 
-.. _documentation: https://cosmo-epfl.github.io/librascal/
+.. _documentation: https://lab-cosmo.github.io/librascal/
+.. _pybind11: https://pybind11.readthedocs.io
 
 Development
 -----------
@@ -84,7 +85,7 @@ following packages installed:
 | ASE         | 3.18 or higher     |
 +-------------+--------------------+
 
-Other necessary packages (such as Eigen and PyBind11) are downloaded
+Other necessary packages (such as Eigen and pybind11) are downloaded
 automatically when compiling Rascal.
 
 The following packages are required for some optional features:
@@ -114,7 +115,7 @@ supporting C++14. During the configuration, it will automatically try to
 download the external libraries on which it depends:
 
 -  Eigen
--  Pybind11
+-  pybind11
 -  Boost (only the unit test framework library)
 -  Python3
 
@@ -340,7 +341,7 @@ in version control.  Use them only for tutorials or *stable* examples that
 are either meant to be run *interactively* or are meant to be processed by
 `sphinx` (`nbsphinx <https://nbsphinx.readthedocs.io/en/latest/>`_) for
 inclusion in the
-`tutorials page <https://cosmo-epfl.github.io/librascal/tutorials/tutorials.html>`_.
+`tutorials page <https://lab-cosmo.github.io/librascal/tutorials/tutorials.html>`_.
 
 Miscellaneous Information
 -------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,12 +26,13 @@ are written in C++14, and are collected in the :file:`/src/` directory, as in th
 case of the :cpp:func:`cdist <cdist>`. This folder is completely agnostic of the
 python bindings, and it should be kept in this way.
 
-The python-bindings is obtained through Pybind11, and the binding subroutines
+The python-bindings is obtained through the pybind11 library, 
+and the binding subroutines
 are included in the :file:`/bindings/` folder. Here, the bind_py_module.cc is
 the file that contains the main binding of the C++ package (in other words, is
 what is needed to use the syntax :python:`import librascal`). The binding for
 each submodule of Rascal and its members are collected in files named
-bind_py_METHOD.cc. We decided to employ Pybind11 because of its seamless
+bind_py_METHOD.cc. We decided to employ pybind11 because of its seamless
 integration between Eigen and numpy. This allows the developer (and the user) to
 code fast and efficient algorithms easily, without losing the power of the C++
 linear algebra as well as numpy simplicity. For more reference, please consult

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ It is strongly recommended to clone librascal from its repository in GitHub.
 
 .. code-block:: bash
 
-    git clone https://github.com/cosmo-epfl/librascal.git
+    git clone https://github.com/lab-cosmo/librascal.git
 
 
 .. include:: ../../README.rst

--- a/docs/source/user_guide/running_md.rst
+++ b/docs/source/user_guide/running_md.rst
@@ -19,7 +19,7 @@ powerful and flexible simulation engine, capable of many advanced simulation
 techniques such as REMD and PIMD and parallel execution of multiple system
 replicas.  It is possible to use ``librascal`` as a "force driver" within i-PI's
 socket calculator interface: Use `this driver script (on github)
-<https://github.com/cosmo-epfl/i-pi/blob/feat/librascal/drivers/py/pes/rascal.py>`_
+<https://github.com/lab-cosmo/i-pi/blob/feat/librascal/drivers/py/pes/rascal.py>`_
 to initialize a saved ``librascal`` model, then run i-PI to connect to the
 socket and run dynamics.  Please consult the i-PI documentation for further
 information on setting up a simulation and using socket calculators.
@@ -47,7 +47,7 @@ Others
 
 If you would like ``librascal`` to support another MD code, please let us know!
 The best way to do this is `open an issue on our github
-<https://github.com/cosmo-epfl/librascal/issues>`_ with the ``enhancement``
+<https://github.com/lab-cosmo/librascal/issues>`_ with the ``enhancement``
 label.
 
 In the meantime, if you can make your MD code call Python code, you may be able

--- a/examples/MLIP_example.ipynb
+++ b/examples/MLIP_example.ipynb
@@ -50,7 +50,7 @@
     "# a collection of distorted ethanol molecules from the ANI-1 dataset \n",
     "# (see https://github.com/isayev/ANI1_dataset) with energies and forces computed using DFTB+ \n",
     "# (see https://www.dftbplus.org/)\n",
-    "url = 'https://raw.githubusercontent.com/cosmo-epfl/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
+    "url = 'https://raw.githubusercontent.com/lab-cosmo/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
     "# Download the file from `url`, save it in a temporary directory and get the\n",
     "# path to it (e.g. '/tmp/tmpb48zma.txt') in the `structures_fn` variable:\n",
     "structures_fn, headers = urllib.request.urlretrieve(url)\n",

--- a/examples/equivariant_demo.ipynb
+++ b/examples/equivariant_demo.ipynb
@@ -88,7 +88,7 @@
     "# a collection of distorted allyl alcohol molecules from the ANI-1 dataset \n",
     "# (see https://github.com/isayev/ANI1_dataset) with energies and forces computed using DFTB+ \n",
     "# (see https://www.dftbplus.org/)\n",
-    "url = 'https://raw.githubusercontent.com/cosmo-epfl/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
+    "url = 'https://raw.githubusercontent.com/lab-cosmo/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
     "# Download the file from `url`, save it in a temporary directory and get the\n",
     "# path to it (e.g. '/tmp/tmpb48zma.txt') in the `structures_fn` variable:\n",
     "structures_fn, headers = urllib.request.urlretrieve(url)\n",

--- a/examples/needs_updating/Spherical_invariants_and_database_exploration.ipynb
+++ b/examples/needs_updating/Spherical_invariants_and_database_exploration.ipynb
@@ -60,7 +60,7 @@
     "# a collection of distorted ethanol molecules from the ANI-1 dataset \n",
     "# (see https://github.com/isayev/ANI1_dataset) with energies and forces computed using DFTB+ \n",
     "# (see https://www.dftbplus.org/)\n",
-    "url = 'https://raw.githubusercontent.com/cosmo-epfl/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
+    "url = 'https://raw.githubusercontent.com/lab-cosmo/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
     "# Download the file from `url`, save it in a temporary directory and get the\n",
     "# path to it (e.g. '/tmp/tmpb48zma.txt') in the `structures_fn` variable:\n",
     "structures_fn, headers = urllib.request.urlretrieve(url)\n",

--- a/examples/nice_demo.ipynb
+++ b/examples/nice_demo.ipynb
@@ -58,7 +58,7 @@
     "# a collection of distorted allyl alcohol molecules from the ANI-1 dataset \n",
     "# (see https://github.com/isayev/ANI1_dataset) with energies and forces computed using DFTB+ \n",
     "# (see https://www.dftbplus.org/)\n",
-    "url = 'https://raw.githubusercontent.com/cosmo-epfl/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
+    "url = 'https://raw.githubusercontent.com/lab-cosmo/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
     "# Download the file from `url`, save it in a temporary directory and get the\n",
     "# path to it (e.g. '/tmp/tmpb48zma.txt') in the `structures_fn` variable:\n",
     "structures_fn, headers = urllib.request.urlretrieve(url)\n",
@@ -662,7 +662,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given that the number of features grows exponentially with body order, some kind of truncation must be applied. NICE features incorporate a Contraction step to compress information at each body order iteration. See the [NICE library](https://github.com/cosmo-epfl/nice/) for a full-fledged implementation. \n",
+    "Given that the number of features grows exponentially with body order, some kind of truncation must be applied. NICE features incorporate a Contraction step to compress information at each body order iteration. See the [NICE library](https://github.com/lab-cosmo/nice/) for a full-fledged implementation. \n",
     "\n",
     "One way to check the amount of information that is lost due to truncation of the NICE iteration (or of the basis set!) is to apply the sum rule from [Goscinski et al. (2021)](https://arxiv.org/pdf/2105.08717), which is a consequence of the orthogonality of CG coefficients. Basically, _for each environment_ the norm of the full $\\nu$-neighbors feature vector is equal to the norm of the $\\nu=1$ equivariants (the density expansion coefficients) raised to the power $\\nu$. Note the norm is to be intended over all equivariant terms, i.e.\n",
     "$$\n",

--- a/examples/optimized_radial_basis_functions.ipynb
+++ b/examples/optimized_radial_basis_functions.ipynb
@@ -60,7 +60,7 @@
     "# a collection of distorted ethanol molecules from the ANI-1 dataset \n",
     "# (see https://github.com/isayev/ANI1_dataset) with energies and forces computed using DFTB+ \n",
     "# (see https://www.dftbplus.org/)\n",
-    "url = 'https://raw.githubusercontent.com/cosmo-epfl/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
+    "url = 'https://raw.githubusercontent.com/lab-cosmo/librascal-example-data/833b4336a7daf471e16993158322b3ea807b9d3f/inputs/molecule_conformers_dftb.xyz'\n",
     "# Download the file from `url`, save it in a temporary directory and get the\n",
     "# path to it (e.g. '/tmp/tmpb48zma.txt') in the `structures_fn` variable:\n",
     "structures_fn, headers = urllib.request.urlretrieve(url)\n",

--- a/examples/zundel_i-PI.ipynb
+++ b/examples/zundel_i-PI.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The present notebook is meant to give you an overview of the main ingredients that you need to build an interatomic potential with `librascal` and use it in connection with i-Pi (https://github.com/cosmo-epfl/i-pi) to generate molecular dynamics (MD) trajectories of the system of interest. \n",
+    "The present notebook is meant to give you an overview of the main ingredients that you need to build an interatomic potential with `librascal` and use it in connection with i-Pi (https://github.com/lab-cosmo/i-pi) to generate molecular dynamics (MD) trajectories of the system of interest. \n",
     "We will start from building a GAP model for Zundel cations ($H_5O_2+$), using a training set obtained via Bowman PES sampling, calculate its RMSE on a test set to check its performance and run a short NVT simulation at $\\text{T} = 250\\,\\text{K}$. \n",
     "\n",
     "The mathematical framework that we are going to use is the kernel-GAP fitting method, using both total energies and atomic forces as target properties. Basically the GAP-model total energy of a zundel molecule is computed using the following expression: \n",
@@ -47,12 +47,12 @@
    "source": [
     "In order to be able to fit a potential with `librascal` (the model evaluator) and interface it with i-Pi (the MD engine) we first need to have both softwares available and correctly installed. For `librascal`, the following should suffice:\n",
     "```bash\n",
-    "$ pip install git+https://github.com/cosmo-epfl/librascal.git\n",
+    "$ pip install git+https://github.com/lab-cosmo/librascal.git\n",
     "```\n",
     "\n",
     "and the same for i-PI:\n",
     "```bash\n",
-    "$ pip install git+https://github.com/cosmo-epfl/i-pi.git\n",
+    "$ pip install git+https://github.com/lab-cosmo/i-pi.git\n",
     "```\n",
     "If these steps don't work, try looking at the `README.rst` files of the respective repositories for further instructions."
    ]
@@ -247,7 +247,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we proceed with the actual calculation of the SOAP vectors of our training set. We need to specify an hyperparameters dictionary, which `librascal` uses to compute the structural features. The meaning of each hyperparameter and how to correctly set them is reported in [the `SphericalInvariants` documentation](https://cosmo-epfl.github.io/librascal/reference/python.html#rascal.representations.SphericalInvariants). These hyperparameters can be used as default values, but a careful optimization of the interaction cutoff might be required in the case the material under investigation might present some mid- or long-range order. \n",
+    "Now we proceed with the actual calculation of the SOAP vectors of our training set. We need to specify an hyperparameters dictionary, which `librascal` uses to compute the structural features. The meaning of each hyperparameter and how to correctly set them is reported in [the `SphericalInvariants` documentation](https://lab-cosmo.github.io/librascal/reference/python.html#rascal.representations.SphericalInvariants). These hyperparameters can be used as default values, but a careful optimization of the interaction cutoff might be required in the case the material under investigation might present some mid- or long-range order. \n",
     "\n",
     "For the actual calculation of the SOAP features, we first create an object of the `SphericalInvariants` class, defined by its hyperparameters. The methods that we then need to use are `transform()}`, which yields a second object called the `manager` containing the representation, while `get_features()` converts it into an $NxM$ matrix, $N$ being the number of atomic environments in the training set and M the number of features per each environment. \n",
     "\n",
@@ -632,7 +632,7 @@
    "source": [
     "Now we are going to use the fitted model to perform a simple NVT simulation at $\\text{T} = 250\\,$K using the i-Pi interface with librascal. For that we will use a communication socket run by i-Pi, which basically outputs a structure produced by the MD and gives it in input to Librascal. This will in turn return energies, forces and stresses by means of the `GenericMDCalculator` class of Librascal. \n",
     "\n",
-    "The job itself will generate a parent process (i-Pi) which contains information of the ensemble, the step needed for the time-integration, the thermostat characteristics, and all other trajectory-related infos. All these information are initially stored in an input.xml file as specified in the i-Pi documentation at https://github.com/cosmo-epfl/i-pi and given as inputs to i-Pi. The Librascal calculator is then launched as a child process and exchanges information with the MD driver.  \n",
+    "The job itself will generate a parent process (i-Pi) which contains information of the ensemble, the step needed for the time-integration, the thermostat characteristics, and all other trajectory-related infos. All these information are initially stored in an input.xml file as specified in the i-Pi documentation at https://github.com/lab-cosmo/i-pi and given as inputs to i-Pi. The Librascal calculator is then launched as a child process and exchanges information with the MD driver.  \n",
     "\n",
     "The Librascal driver in i-Pi needs some input parameters, that can be given directly in the command line when the driver is called. To check the needed information, just use the --help option when calling it, as shown below.\n",
     "\n",


### PR DESCRIPTION
While reading the documentation I found a few minor thinks which are addressed in this PR.

This PR changes all links to the new location of the repository. 
Additionally, `pybind11` is now written consistently and according to pybind's naming convention.
