### PR TITLE
Fix imports on Python 3.10

### DIFF
--- a/bindings/rascal/utils/io.py
+++ b/bindings/rascal/utils/io.py
@@ -1,6 +1,6 @@
 import os
 import importlib
-from collections import Iterable
+from collections.abc import Iterable
 import numpy as np
 import json
 from copy import deepcopy

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ sphinx>=2.1.2,<=4.0.2
 breathe>=4.14.1
 # Jinja2 v3 breaks nbsphinx
 jinja2==2.11.3
+MarkupSafe==2.0.1
 sphinx_rtd_theme
 # notebook tutorials
 nbsphinx>=0.8.1


### PR DESCRIPTION
`collections.Iterable` has been deprecated for a while and was removed in Python 3.10. The correct import is `collections.abc.Iterable`, which was already used in other parts of the code.
