### PR TITLE
Remove -march=native from default flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,6 @@ option(BUILD_SANDBOX "If on, builds the sandbox" OFF)
 
 set(INSTALL_PATH "" CACHE STRING "Path to install the libraries")
 
-SET(TYPE_ARCHITECTURE "native" CACHE STRING
-    "Choose the type of architecture to compile to in release mode."
-)
-
 ########## COMPILATION FLAGS ##########
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Weffc++ -Wno-non-virtual-dtor")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
@@ -57,14 +53,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
 
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Og")
-
-    # Add -march=${TYPE_ARCHITECTURE} (-march=native by default) to the release
-    # build flags
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=${TYPE_ARCHITECTURE}")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=${TYPE_ARCHITECTURE}")
-
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -march=${TYPE_ARCHITECTURE}")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=${TYPE_ARCHITECTURE}")
 endif()
 
 ########## START CONFIGURATION ##########

--- a/bindings/rascal/representations/spherical_covariants.py
+++ b/bindings/rascal/representations/spherical_covariants.py
@@ -314,10 +314,10 @@ class SphericalCovariants(BaseIO):
                         * self.hypers["max_angular"]
                     )
                 n_col *= 2 * self.hypers["covariant_lambda"] + 1
-                return int(n_col * n_species ** 2 * self.hypers["max_radial"] ** 2)
+                return int(n_col * n_species**2 * self.hypers["max_radial"] ** 2)
             else:
                 return (
-                    n_species ** 2
+                    n_species**2
                     * self.hypers["max_radial"] ** 2
                     * int(
                         (

--- a/bindings/rascal/utils/cg_utils.py
+++ b/bindings/rascal/utils/cg_utils.py
@@ -240,15 +240,12 @@ def compute_lambda_soap(spx, cg, lam, parity=0):
                 continue
             if l2 - l1 > lam or l2 + l1 < lam:
                 continue
-            lsoap[..., nl, :] = (
-                cg.combine_einsum(
-                    spx[..., lm_slice(l1)],
-                    spx[..., lm_slice(l2)],
-                    lam,
-                    combination_string="ian,iAN->ianAN",
-                )
-                * (1 if l2 == l1 else SQRT_2)
-            )
+            lsoap[..., nl, :] = cg.combine_einsum(
+                spx[..., lm_slice(l1)],
+                spx[..., lm_slice(l2)],
+                lam,
+                combination_string="ian,iAN->ianAN",
+            ) * (1 if l2 == l1 else SQRT_2)
             nl += 1
     return lsoap
 

--- a/bindings/rascal/utils/radial_basis.py
+++ b/bindings/rascal/utils/radial_basis.py
@@ -94,7 +94,7 @@ def gto_width(sigma):
     ---Returns---
     b: GTO (Gaussian) width
     """
-    return 1.0 / (2 * sigma ** 2)
+    return 1.0 / (2 * sigma**2)
 
 
 def gto_prefactor(n, sigma):
@@ -125,7 +125,7 @@ def gto(r, n, sigma):
     """
     b = gto_width(sigma)
     N = gto_prefactor(n, sigma)
-    return N * r ** (n + 1) * np.exp(-b * r ** 2)
+    return N * r ** (n + 1) * np.exp(-b * r**2)
 
 
 def gto_overlap(n, m, sigma_n, sigma_m):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ nbsphinx>=0.8.1
 pygments>=2.4.1
 # Developers tools for linting and formatting
 cpplint==1.5.5
-black==20.8b1
+black==22.3.0
 # Developers tools - data generation scripts
 ase
 mpmath

--- a/scripts/generate_modified_bessel_first_kind_ref_data.py
+++ b/scripts/generate_modified_bessel_first_kind_ref_data.py
@@ -27,7 +27,7 @@ def sbesseli_complete_square(n, a, r, x):
     """i_n(2arx)*\exp{-ar^2}*\exp{-ax^2}"""
     z = 2 * a * r * x
     return float(
-        sqrt(pi / (2 * z)) * besseli(n + 0.5, z) * exp(-a * r ** 2) * exp(-a * x ** 2)
+        sqrt(pi / (2 * z)) * besseli(n + 0.5, z) * exp(-a * r**2) * exp(-a * x**2)
     )
 
 

--- a/scripts/generate_spherical_covariant_ref_data.py
+++ b/scripts/generate_spherical_covariant_ref_data.py
@@ -146,7 +146,7 @@ def main(json_dump, save_kernel):
 
     x = get_feature_vector(test_hypers, frames)
     x0 = x.shape[0]
-    x = x.reshape((x0, 3, -1, (2 * lam + 1), nmax ** 2))
+    x = x.reshape((x0, 3, -1, (2 * lam + 1), nmax**2))
     x = x.transpose((0, 3, 1, 2, 4))
     x = x.reshape((x0 * (2 * lam + 1), -1))
     kernel = np.dot(x, x.T)


### PR DESCRIPTION
This is broken in multiple ways right now: #383, #335. I also got a different error when trying to build librascal on a fresh M1 install (macOS Monterey):

```
-- The C compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/guillaume/code/librascal/_cmake_test_compile/build
-- Build type is: Release
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Downloading wigxjpf
-- Downloading Eigen3
-- Eigen3 3.3.4
-- Found PythonInterp: /Users/guillaume/code/librascal/virtualenv/bin/python (found suitable version "3.10", minimum required is "3")
-- Found PythonLibs: /opt/miniforge3/lib/libpython3.10.dylib
-- Downloading pybind11
-- pybind11 v2.3.0
-- Installation ROOT: /Users/guillaume/code/librascal/_skbuild/macosx-12.0-arm64-3.10/cmake-install
-- The project is built using scikit-build
-- The optional cpplint parser has not been found. For more information see https://pypi.python.org/pypi/cpplint
-- clang-format not found, so the pretty-cpp target is unavailable
-- BLACK auto formatter: /opt/miniforge3/bin/black
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/guillaume/code/librascal/_skbuild/macosx-12.0-arm64-3.10/cmake-build
[1/20] Building CXX object src/CMakeFiles/rascal.dir/rascal/utils/json_io.cc.o
FAILED: src/CMakeFiles/rascal.dir/rascal/utils/json_io.cc.o
/Library/Developer/CommandLineTools/usr/bin/c++ -Drascal_EXPORTS -I/Users/guillaume/code/librascal/src -isystem /Users/guillaume/code/librascal/_skbuild/macosx-12.0-arm64-3.10/cmake-build/external/Eigen3 -isystem /Users/guillaume/code/librascal/_skbuild/macosx-12.0-arm64-3.10/cmake-build/external/wigxjpf/inc -isystem /Users/guillaume/code/librascal/_skbuild/macosx-12.0-arm64-3.10/cmake-build/external/wigxjpf/cfg -Wall -Wextra -Weffc++ -Wno-non-virtual-dtor -O3 -DNDEBUG -march=native -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.3.sdk -mmacosx-version-min=12.0 -fPIC -Werror -std=gnu++14 -MD -MT src/CMakeFiles/rascal.dir/rascal/utils/json_io.cc.o -MF src/CMakeFiles/rascal.dir/rascal/utils/json_io.cc.o.d -o src/CMakeFiles/rascal.dir/rascal/utils/json_io.cc.o -c /Users/guillaume/code/librascal/src/rascal/utils/json_io.cc
clang: error: the clang compiler does not support '-march=native'
```

Users who want to use `-march=native` can still specify it in `CMAKE_CXX_FLAGS` and get any corresponding benefits.