### PR TITLE
Bugfix: Overlap matrix had extra normalization

### DIFF
--- a/src/rascal/representations/calculator_spherical_expansion.hh
+++ b/src/rascal/representations/calculator_spherical_expansion.hh
@@ -403,8 +403,7 @@ namespace rascal {
       void precompute() override {
         this->precompute_radial_sigmas();
         this->precompute_radial_overlap();
-        this->ortho_norm_matrix =
-            this->radial_norm_factors.asDiagonal() * this->radial_ortho_matrix;
+        this->ortho_norm_matrix = this->radial_ortho_matrix;
 
         this->hyp1f1_calculator.precompute(this->max_radial, this->max_angular);
       }
@@ -655,14 +654,8 @@ namespace rascal {
             overlap(radial_n1, radial_n2) =
                 pow(0.5 / pow(this->radial_sigmas[radial_n1], 2) +
                         0.5 / pow(this->radial_sigmas[radial_n2], 2),
-                    -0.5 * (3.0 + radial_n1 + radial_n2)) /
-                (pow(this->radial_sigmas[radial_n1], radial_n1) *
-                 pow(this->radial_sigmas[radial_n2], radial_n2)) *
-                tgamma(0.5 * (3.0 + radial_n1 + radial_n2)) /
-                (pow(this->radial_sigmas[radial_n1] *
-                         this->radial_sigmas[radial_n2],
-                     1.5) *
-                 sqrt(tgamma(1.5 + radial_n1) * tgamma(1.5 + radial_n2)));
+                    -0.5 * (3.0 + radial_n1 + radial_n2)) *  
+                tgamma(0.5 * (3.0 + radial_n1 + radial_n2)) * 0.5;
           }
         }
         // Compute the inverse square root of the overlap matrix


### PR DESCRIPTION
Fixes the wrong orthonormalization in rascal for GTO basis.

The code was mixing two conventions for the GTOs.
The overlap matrix was defined using the normalized GTOs, while the rest of the code is using the primitive GTOs (just the r^n times Gaussian part). Now, the coefficients obtained from librascal agree with those from "exact calculations" and those from pyLODE up to a global factor.

The original code was trying to take the extra normalization into account by multiplying the expansion coefficients again with the same normalization factors. Most likely, there was something wrong in the execution of these steps. We are trying to understand this in more detail, but for the time being, the new coefficients agree with the approaches mentioned above and seem to be correct.

Still TODO:
- [ ] Fix some errors associated with this in the documentation.
- [ ] Clean up code to remove code fragments belonging to redundant normalization steps