### PR TITLE
Adapt cpp representation input paramaters compatible with the current lammps-rascal interface

### DIFF
--- a/bindings/rascal/models/kernels.py
+++ b/bindings/rascal/models/kernels.py
@@ -107,9 +107,21 @@ class Kernel(BaseIO):
 
     def _set_data(self, data):
         super()._set_data(data)
+        # allows to load deprecated models
+        if "cpp_kernel" in data.keys():
+            self._kernel = self._kernel.from_dict(data["cpp_kernel"])
+        else:
+            print(
+                "WARNING: a deprecated model was loaded. Key 'cpp_kernel' "
+                "was not found in model. Please dump and reload the model "
+                "to update it. The model parameters will not change, only "
+                "the format."
+            )
 
     def _get_data(self):
-        return super()._get_data()
+        data = super()._get_data()
+        data.update(cpp_kernel=self._kernel.to_dict())
+        return data
 
     def __call__(self, X, Y=None, grad=(False, False), compute_neg_stress=False):
         """

--- a/bindings/rascal/models/krr.py
+++ b/bindings/rascal/models/krr.py
@@ -209,8 +209,13 @@ class KRR(BaseIO):
 
         return -neg_stress
 
-    def get_weights(self):
-        return self.weights
+    @property
+    def weights(self):
+        return self._weights
+
+    @weights.setter
+    def weights(self, weights):
+        self._weights = weights.reshape(-1)
 
     def _get_init_params(self):
         init_params = dict(

--- a/bindings/rascal/representations/spherical_covariants.py
+++ b/bindings/rascal/representations/spherical_covariants.py
@@ -377,6 +377,20 @@ class SphericalCovariants(BaseIO):
 
     def _set_data(self, data):
         super()._set_data(data)
+        # allows to load deprecated models
+        if "cpp_representation" in data.keys():
+            self._representation = self._representation.from_dict(
+                data["cpp_representation"]
+            )
+        else:
+            print(
+                "WARNING: a deprecated model was loaded. Key "
+                "'cpp_representation' was not found in model. Please dump and "
+                "reload the model to update it. The model parameters will not "
+                "change, only the format."
+            )
 
     def _get_data(self):
-        return super()._get_data()
+        data = super()._get_data()
+        data.update(cpp_representation=self._representation.to_dict())
+        return data

--- a/bindings/rascal/representations/spherical_expansion.py
+++ b/bindings/rascal/representations/spherical_expansion.py
@@ -322,6 +322,20 @@ class SphericalExpansion(BaseIO):
 
     def _set_data(self, data):
         super()._set_data(data)
+        # allows to load deprecated models
+        if "cpp_representation" in data.keys():
+            self._representation = self._representation.from_dict(
+                data["cpp_representation"]
+            )
+        else:
+            print(
+                "WARNING: a deprecated model was loaded. Key "
+                "'cpp_representation' was not found in model. Please dump and "
+                "reload the model to update it. The model parameters will not "
+                "change, only the format."
+            )
 
     def _get_data(self):
-        return super()._get_data()
+        data = super()._get_data()
+        data.update(cpp_representation=self._representation.to_dict())
+        return data

--- a/bindings/rascal/representations/spherical_invariants.py
+++ b/bindings/rascal/representations/spherical_invariants.py
@@ -439,6 +439,20 @@ class SphericalInvariants(BaseIO):
 
     def _set_data(self, data):
         super()._set_data(data)
+        # allows to load deprecated models
+        if "cpp_representation" in data.keys():
+            self._representation = self._representation.from_dict(
+                data["cpp_representation"]
+            )
+        else:
+            print(
+                "WARNING: a deprecated model was loaded. Key "
+                "'cpp_representation' was not found in model. Please dump and "
+                "reload the model to update it. The model parameters will not "
+                "change, only the format."
+            )
 
     def _get_data(self):
-        return super()._get_data()
+        data = super()._get_data()
+        data.update(cpp_representation=self._representation.to_dict())
+        return data


### PR DESCRIPTION
This is a PR from this commit.
https://github.com/lab-cosmo/librascal/pull/376/commits/2a879b7ffabefb21f937366c0b944a6edee895ec

To use the current lammps-rascal interface conveniently, we however don't take the newest format version #376 which is cleaner, but the older version compatible with the branch `feat/lammps_preparations` which is used for the current version of the lammps-rascal interface.

EDIT:
This is so people do not need to have to install a librascal version just to format the ML model json correctly compatible with lammps-rascal