### PR TITLE
solvers changes 

### DIFF
--- a/tests/python/test_filter.py
+++ b/tests/python/test_filter.py
@@ -232,7 +232,7 @@ class FilterTest:
         compressor = self._filter(self.repr, n_sparses, act_on="sample per species")
         with self.assertRaisesRegex(
             ValueError,
-            r"Found array with 0 sample\(s\) \(shape=\(0, 4480\)\) while a minimum of 1 is required.",
+            r"Found array with 0 sample\(s\) \(shape=\(0, 4480\)\) while a minimum of 2 is required.",
         ):
             compressor.select_and_filter(self.managers)
 


### PR DESCRIPTION
(Describe your pull request in 1-2 sentences)
added solvers rkhs, rkhs-qr and qr from gaptools also added a option "lstsq" to uses lstsq with the old method ( numpy.linalg.lstsq(rcond=-1) )

train_gap_model works out-of-the-box with the older versions. The default solver stays the same, other solver as simply made available by the PR

Fix # (optional)

Rationale and detailed description of the changes:

- added solvers rkhs, rkhs-qr and qr from gaptools
- train_gap_model is "retro-compatible" but uses as default RKHS-QR
- added solver "lstsq" which uses numpy.linalg.lstsq(rcond=-1)

Tasks before review:

- [ ] Add tests, examples, and complete documentation of any added functionality
    - [ ] Make sure the autogenerated documentation appears in Sphinx and is
          formatted correctly (ask @max-veit if you need help with this task).
- [x] Run `make lint` on the project, ensure it passes
    - [x] Run `make pretty-cpp` and `make pretty-python`, check that the
          auto-formatting is sensible

