### PR TITLE
Do not compile with -Werror by default

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -10,7 +10,6 @@ set(BINDING_SRCS
 # NO_EXTRAS: do not setup LTO (link time optimization) and striping of the
 #            shared library
 pybind11_add_module(_rascal ${BINDING_SRCS} SYSTEM NO_EXTRAS)
-target_compile_options(_rascal PRIVATE -Werror)
 
 target_link_libraries(_rascal PRIVATE "${LIBRASCAL_NAME}")
 # Remove the 'lib' prefix, so that the python module is called _rascal

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,6 @@ set(RASCAL_SOURCES
 add_library(${LIBRASCAL_NAME} ${RASCAL_SOURCES})
 
 target_include_directories(${LIBRASCAL_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_options(${LIBRASCAL_NAME} PRIVATE -Werror)
 
 target_link_libraries(${LIBRASCAL_NAME} PUBLIC Eigen3::Eigen)
 target_link_libraries(${LIBRASCAL_NAME} PUBLIC ${WIGXJPF_NAME})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,8 +43,6 @@ foreach(_file_ ${tests})
     # make sure all tests include the boost that has been found
     target_include_directories(${_name_} SYSTEM PRIVATE ${Boost_INCLUDE_DIR})
     target_link_libraries(${_name_} rascal_tests_main)
-    target_compile_options(${_name_} PRIVATE -Werror)
-
 
     add_test(
         NAME ${_name_}


### PR DESCRIPTION
Should help with #422, at least the `cc1plus: all warnings being treated as errors` part.