### PR TITLE
replace skcosmo by skmatter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ The following packages are required for some optional features:
 +--------------------------+-------------+--------------------+
 | Feature                  | Package     | Required version   |
 +==========================+=============+====================+
-| Feature compression      | skcosmo     | 0.1.0 or later     |
+| Feature compression      | skmatter    | 0.1.0 or later     |
 +--------------------------+-------------+--------------------+
 | Rotational algebra       | sympy       | 1.4 or later       |
 | (Clebsch-Gordan coeffs.) |             |                    |

--- a/bindings/rascal/utils/filter.py
+++ b/bindings/rascal/utils/filter.py
@@ -7,10 +7,10 @@ from ..representations.spherical_invariants import SphericalInvariants
 LOGGER = logging.getLogger(__name__)
 
 try:
-    from skcosmo._selection import _FPS, _CUR
+    from skmatter._selection import _FPS, _CUR
 except ImportError as ie:
     LOGGER.warn(
-        "Warning: skcosmo module not found. CUR and FPS filters will be unavailable."
+        "Warning: skmatter module not found. CUR and FPS filters will be unavailable."
     )
     LOGGER.warn("Original error:\n" + str(ie))
     _FPS = _CUR = None

--- a/examples/Feature_selection_example.ipynb
+++ b/examples/Feature_selection_example.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "Now we will introduce a technique to further optimize the computational cost of the model, and it consists of applying the same sparsification technique along the _features_ (columns) of the feature matrix, in addition to the _samples_ (rows).  This technique was introduced in Ref. [1] and has since been used in numerous applications. Feature selection and sparse feature computation are both available directly in librascal, and this example aims to show the user how to apply them in a realistic setting.\n",
     "\n",
-    "A detail on the selection algorithm itself: `librascal` uses the FPS and CUR algorithms implemented in [`scikit-cosmo`](https://scikit-cosmo.readthedocs.io/en/latest/selection.html).  You will therefore need to have `scikit-cosmo` installed (`pip install skmatter`) to run this notebook.  Note also that further selection algorithms, notably PCovCUR and PCovFPS, are implemented in `skmatter` but not yet included directly in `librascal`.\n",
+    "A detail on the selection algorithm itself: `librascal` uses the FPS and CUR algorithms implemented in [`scikit-matter`](https://scikit-cosmo.readthedocs.io/en/latest/selection.html).  You will therefore need to have `scikit-matter` installed (`pip install skmatter`) to run this notebook.  Note also that further selection algorithms, notably PCovCUR and PCovFPS, are implemented in `skmatter` but not yet included directly in `librascal`.\n",
     "\n",
     "[1]: G. Imbalzano, A. Anelli, D. Giofré, S. Klees, J. Behler, and M. Ceriotti, Automatic Selection of Atomic Fingerprints and Reference Configurations for Machine-Learning Potentials, J. Chem. Phys. 148, 241730 (2018). [doi:10.1063/1.5024611](https://aip.scitation.org/doi/full/10.1063/1.5024611)\n",
     "\n",
@@ -1003,7 +1003,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/examples/Feature_selection_example.ipynb
+++ b/examples/Feature_selection_example.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "Now we will introduce a technique to further optimize the computational cost of the model, and it consists of applying the same sparsification technique along the _features_ (columns) of the feature matrix, in addition to the _samples_ (rows).  This technique was introduced in Ref. [1] and has since been used in numerous applications. Feature selection and sparse feature computation are both available directly in librascal, and this example aims to show the user how to apply them in a realistic setting.\n",
     "\n",
-    "A detail on the selection algorithm itself: `librascal` uses the FPS and CUR algorithms implemented in [`scikit-cosmo`](https://scikit-cosmo.readthedocs.io/en/latest/selection.html).  You will therefore need to have `scikit-cosmo` installed (`pip install skcosmo`) to run this notebook.  Note also that further selection algorithms, notably PCovCUR and PCovFPS, are implemented in `skcosmo` but not yet included directly in `librascal`.\n",
+    "A detail on the selection algorithm itself: `librascal` uses the FPS and CUR algorithms implemented in [`scikit-cosmo`](https://scikit-cosmo.readthedocs.io/en/latest/selection.html).  You will therefore need to have `scikit-cosmo` installed (`pip install skmatter`) to run this notebook.  Note also that further selection algorithms, notably PCovCUR and PCovFPS, are implemented in `skmatter` but not yet included directly in `librascal`.\n",
     "\n",
     "[1]: G. Imbalzano, A. Anelli, D. Giofré, S. Klees, J. Behler, and M. Ceriotti, Automatic Selection of Atomic Fingerprints and Reference Configurations for Machine-Learning Potentials, J. Chem. Phys. 148, 241730 (2018). [doi:10.1063/1.5024611](https://aip.scitation.org/doi/full/10.1063/1.5024611)\n",
     "\n",

--- a/examples/Feature_selection_example.ipynb
+++ b/examples/Feature_selection_example.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "Now we will introduce a technique to further optimize the computational cost of the model, and it consists of applying the same sparsification technique along the _features_ (columns) of the feature matrix, in addition to the _samples_ (rows).  This technique was introduced in Ref. [1] and has since been used in numerous applications. Feature selection and sparse feature computation are both available directly in librascal, and this example aims to show the user how to apply them in a realistic setting.\n",
     "\n",
-    "A detail on the selection algorithm itself: `librascal` uses the FPS and CUR algorithms implemented in [`scikit-matter`](https://scikit-cosmo.readthedocs.io/en/latest/selection.html).  You will therefore need to have `scikit-matter` installed (`pip install skmatter`) to run this notebook.  Note also that further selection algorithms, notably PCovCUR and PCovFPS, are implemented in `skmatter` but not yet included directly in `librascal`.\n",
+    "A detail on the selection algorithm itself: `librascal` uses the FPS and CUR algorithms implemented in [`scikit-matter`](https://scikit-matter.readthedocs.io/en/latest/selection.html).  You will therefore need to have `scikit-matter` installed (`pip install skmatter`) to run this notebook.  Note also that further selection algorithms, notably PCovCUR and PCovFPS, are implemented in `skmatter` but not yet included directly in `librascal`.\n",
     "\n",
     "[1]: G. Imbalzano, A. Anelli, D. Giofré, S. Klees, J. Behler, and M. Ceriotti, Automatic Selection of Atomic Fingerprints and Reference Configurations for Machine-Learning Potentials, J. Chem. Phys. 148, 241730 (2018). [doi:10.1063/1.5024611](https://aip.scitation.org/doi/full/10.1063/1.5024611)\n",
     "\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy
 scipy
 jupyter
 sympy>=1.4
-skcosmo
+skmatter
 # notebook tutorials
 matplotlib
 # Developers tools for compiling documentation


### PR DESCRIPTION
Fix #424

Rationale and detailed description of the changes:

- the code still refers to deprecated skcosmo instead of skmatter
